### PR TITLE
Detect ambiguous labels

### DIFF
--- a/goto.py
+++ b/goto.py
@@ -120,6 +120,9 @@ def _find_labels_and_gotos(code):
             if opname2 == 'LOAD_ATTR' and opname3 == 'POP_TOP':
                 name = code.co_names[oparg1]
                 if name == 'label':
+                    if oparg2 in labels:
+                        co_name = code.co_names[oparg2]
+                        raise SyntaxError('Ambiguous label {0!r}'.format(co_name))
                     labels[oparg2] = (offset1,
                                       offset4,
                                       tuple(block_stack))

--- a/test_goto.py
+++ b/test_goto.py
@@ -174,6 +174,15 @@ def test_jump_to_unknown_label():
     pytest.raises(SyntaxError, with_goto, func)
 
 
+def test_jump_to_ambiguous_label():
+    def func():
+        label .ambiguous
+        goto .ambiguous
+        label .ambiguous
+
+    pytest.raises(SyntaxError, with_goto, func)
+
+
 def test_function_is_copy():
     def func():
         pass


### PR DESCRIPTION
This feature could be used to throw appropriate Exception when multiple labels with the same name are created (via code generation or etc.).