### PR TITLE
Properly fix `Jump out of too many nested blocks` error

### DIFF
--- a/goto.py
+++ b/goto.py
@@ -189,7 +189,7 @@ def _patch_code(code):
             pos = _write_instruction(buf, pos, 'JUMP_ABSOLUTE', len(buf) // _BYTECODE.jump_unit)
             
             if pos > end:
-                raise SyntaxError('Internal error - not enough bytecode space')
+                raise SyntaxError('Goto in an incredibly huge function') # not sure if reachable
             
             size += _get_instruction_size('JUMP_ABSOLUTE', end // _BYTECODE.jump_unit)
             

--- a/test_goto.py
+++ b/test_goto.py
@@ -71,63 +71,87 @@ def test_jump_into_loop():
 
     pytest.raises(SyntaxError, with_goto, func)
 
-if sys.version_info >= (3, 6):
-    def test_jump_out_of_nested_2_loops():
-        @with_goto
-        def func():
-            x = 1
-            for i in range(2):
-                for j in range(2):
-                    # These are more than 256 bytes of bytecode, requiring
-                    # a JUMP_FORWARD below on Python 3.6+, since the absolute
-                    # address would be too large, after leaving two blocks.
-                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
-                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
-                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+def test_jump_out_of_nested_2_loops():
+    @with_goto
+    def func():
+        x = 1
+        for i in range(2):
+            for j in range(2):
+                # These are more than 256 bytes of bytecode
+                x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+                x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+                x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
 
+                goto .end
+        label .end
+        return (i, j)
+
+    assert func() == (0, 0)
+
+def test_jump_out_of_nested_3_loops():
+    @with_goto
+    def func():
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
                     goto .end
-            label .end
-            return (i, j)
+        label .end
+        return (i, j, k)
 
-        assert func() == (0, 0)
+    assert func() == (0, 0, 0)
 
-    def test_jump_out_of_nested_3_loops():
-        def func():
-            for i in range(2):
-                for j in range(2):
-                    for k in range(2):
+def test_jump_out_of_nested_4_loops():
+    @with_goto
+    def func():
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
+                    for m in range(2):
                         goto .end
-            label .end
-            return (i, j, k)
+        label .end
+        return (i, j, k, m)
 
-        pytest.raises(SyntaxError, with_goto, func)
-else:
-    def test_jump_out_of_nested_4_loops():
-        @with_goto
-        def func():
-            for i in range(2):
-                for j in range(2):
-                    for k in range(2):
-                        for m in range(2):
+    assert func() == (0, 0, 0, 0)
+
+def test_jump_out_of_nested_5_loops():
+    @with_goto
+    def func():
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
+                    for m in range(2):
+                        for n in range(2):
                             goto .end
-            label .end
-            return (i, j, k, m)
+        label .end
+        return (i, j, k, m, n)
 
-        assert func() == (0, 0, 0, 0)
+    assert func() == (0, 0, 0, 0, 0)
 
-    def test_jump_out_of_nested_5_loops():
-        def func():
-            for i in range(2):
-                for j in range(2):
-                    for k in range(2):
-                        for m in range(2):
-                            for n in range(2):
-                                goto .end
-            label .end
-            return (i, j, k, m, n)
+def test_jump_out_of_nested_11_loops():
+    @with_goto
+    def func():
+        x = 1
+        for i1 in range(2):
+            for i2 in range(2):
+                for i3 in range(2):
+                    for i4 in range(2):
+                        for i5 in range(2):
+                            for i6 in range(2):
+                                for i7 in range(2):
+                                    for i8 in range(2):
+                                        for i9 in range(2):
+                                            for i10 in range(2):
+                                                for i11 in range(2):
+                                                    # These are more than 256 bytes of bytecode
+                                                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+                                                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+                                                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+                                    
+                                                    goto .end
+        label .end
+        return (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11)
 
-        pytest.raises(SyntaxError, with_goto, func)
-
+    assert func() == (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
 def test_jump_across_loops():
     def func():


### PR DESCRIPTION
This fixes issue #19 

The fix is to - if there isn't enough space to write the new bytecode in-place - write it at the end of the bytecode array and add jumps to/from there.

It replaces the previous attempted fix for this issue, as including both would be too complex and
is unneeded.

The tests have been updated (previously they were checking that the issue exists), and a new even more extreme test has been added.
Result observed to work correctly in "real" code. (No, not production code :P)

Tested on pypy3.6
Please test on other python versions. (I can't easily install them here)