### PR TITLE
Properly fix `Jump out of too many nested blocks` error 

### DIFF
--- a/goto.py
+++ b/goto.py
@@ -189,7 +189,7 @@ def _patch_code(code):
             pos = _write_instruction(buf, pos, 'JUMP_ABSOLUTE', len(buf) // _BYTECODE.jump_unit)
             
             if pos > end:
-                raise SyntaxError('Internal error - not enough bytecode space')
+                raise SyntaxError('Goto in an incredibly huge function') # not sure if reachable
             
             size += _get_instruction_size('JUMP_ABSOLUTE', end // _BYTECODE.jump_unit)
             

--- a/goto.py
+++ b/goto.py
@@ -100,6 +100,15 @@ def _get_instruction_size(opname, oparg=0):
 
     return size
 
+def _get_instructions_size(ops):
+    size = 0
+    for op in ops:
+        if isinstance(op, str):
+            size += _get_instruction_size(op)
+        else:
+            size += _get_instruction_size(*op)
+    return size
+
 def _write_instruction(buf, pos, opname, oparg=0):
     extended_arg = oparg >> _BYTECODE.argument_bits
     if extended_arg != 0:
@@ -116,6 +125,13 @@ def _write_instruction(buf, pos, opname, oparg=0):
 
     return pos
 
+def _write_instructions(buf, pos, ops):
+    for op in ops:
+        if isinstance(op, str):
+            pos = _write_instruction(buf, pos, op)
+        else:
+            pos = _write_instruction(buf, pos, *op)
+    return pos
 
 def _find_labels_and_gotos(code):
     labels = {}
@@ -178,35 +194,28 @@ def _patch_code(code):
         if origin_stack[:target_depth] != target_stack:
             raise SyntaxError('Jump into different block')
 
-        size = 0
+        ops = []
         for i in range(len(origin_stack) - target_depth):
-            size += _get_instruction_size('POP_BLOCK')
-        size += _get_instruction_size('JUMP_ABSOLUTE', target // _BYTECODE.jump_unit)
+            ops.append('POP_BLOCK')
+        ops.append(('JUMP_ABSOLUTE', target // _BYTECODE.jump_unit))
 
-        moved_to_end = False
-        if pos + size > end:
-            # not enough space, add at end
-            pos = _write_instruction(buf, pos, 'JUMP_ABSOLUTE', len(buf) // _BYTECODE.jump_unit)
+        if pos + _get_instructions_size(ops) > end:
+            # not enough space, add code at buffer end and jump there
+            buf_end = len(buf)
 
-            if pos > end:
-                raise SyntaxError('Goto in an incredibly huge function') # not sure if reachable
+            go_to_end_ops = [('JUMP_ABSOLUTE', buf_end // _BYTECODE.jump_unit)]
 
-            size += _get_instruction_size('JUMP_ABSOLUTE', end // _BYTECODE.jump_unit)
+            if pos + _get_instructions_size(go_to_end_ops) > end:
+                # not sure if reachable
+                raise SyntaxError('Goto in an incredibly huge function')
 
-            moved_to_end = True
-            pos = len(buf)
-            buf.extend([0] * size)
+            pos = _write_instructions(buf, pos, go_to_end_ops)
+            _inject_nop_sled(buf, pos, end)
 
-        try:
-            for i in range(len(origin_stack) - target_depth):
-                pos = _write_instruction(buf, pos, 'POP_BLOCK')
-            pos = _write_instruction(buf, pos, 'JUMP_ABSOLUTE', target // _BYTECODE.jump_unit)
-        except (IndexError, struct.error) as e:
-            raise SyntaxError("Internal error")
-
-        if moved_to_end:
-            pos = _write_instruction(buf, pos, 'JUMP_ABSOLUTE', end // _BYTECODE.jump_unit)
+            buf.extend([0] * _get_instructions_size(ops))
+            _write_instructions(buf, buf_end, ops)
         else:
+            pos = _write_instructions(buf, pos, ops)
             _inject_nop_sled(buf, pos, end)
 
     return _make_code(code, _array_to_bytes(buf))

--- a/test_goto.py
+++ b/test_goto.py
@@ -88,45 +88,6 @@ def test_jump_out_of_nested_2_loops():
 
     assert func() == (0, 0)
 
-def test_jump_out_of_nested_3_loops():
-    @with_goto
-    def func():
-        for i in range(2):
-            for j in range(2):
-                for k in range(2):
-                    goto .end
-        label .end
-        return (i, j, k)
-
-    assert func() == (0, 0, 0)
-
-def test_jump_out_of_nested_4_loops():
-    @with_goto
-    def func():
-        for i in range(2):
-            for j in range(2):
-                for k in range(2):
-                    for m in range(2):
-                        goto .end
-        label .end
-        return (i, j, k, m)
-
-    assert func() == (0, 0, 0, 0)
-
-def test_jump_out_of_nested_5_loops():
-    @with_goto
-    def func():
-        for i in range(2):
-            for j in range(2):
-                for k in range(2):
-                    for m in range(2):
-                        for n in range(2):
-                            goto .end
-        label .end
-        return (i, j, k, m, n)
-
-    assert func() == (0, 0, 0, 0, 0)
-
 def test_jump_out_of_nested_11_loops():
     @with_goto
     def func():
@@ -142,11 +103,18 @@ def test_jump_out_of_nested_11_loops():
                                         for i9 in range(2):
                                             for i10 in range(2):
                                                 for i11 in range(2):
-                                                    # These are more than 256 bytes of bytecode
-                                                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
-                                                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
-                                                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
-                                    
+                                                    # These are more than
+                                                    # 256 bytes of bytecode
+                                                    x += (x+x+x+x+x+x+x+x+x+
+                                                          x+x+x+x+x+x+x+x+x+
+                                                          x+x+x+x+x+x+x+x+x)
+                                                    x += (x+x+x+x+x+x+x+x+x+
+                                                          x+x+x+x+x+x+x+x+x+
+                                                          x+x+x+x+x+x+x+x+x)
+                                                    x += (x+x+x+x+x+x+x+x+x+
+                                                          x+x+x+x+x+x+x+x+x+
+                                                          x+x+x+x+x+x+x+x+x)
+
                                                     goto .end
         label .end
         return (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11)

--- a/test_goto.py
+++ b/test_goto.py
@@ -71,63 +71,87 @@ def test_jump_into_loop():
 
     pytest.raises(SyntaxError, with_goto, func)
 
-if sys.version_info >= (3, 6):
-    def test_jump_out_of_nested_2_loops():
-        @with_goto
-        def func():
-            x = 1
-            for i in range(2):
-                for j in range(2):
-                    # These are more than 256 bytes of bytecode, requiring
-                    # a JUMP_FORWARD below on Python 3.6+, since the absolute
-                    # address would be too large, after leaving two blocks.
-                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
-                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
-                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+def test_jump_out_of_nested_2_loops():
+    @with_goto
+    def func():
+        x = 1
+        for i in range(2):
+            for j in range(2):
+                # These are more than 256 bytes of bytecode
+                x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+                x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+                x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
 
+                goto .end
+        label .end
+        return (i, j)
+
+    assert func() == (0, 0)
+
+def test_jump_out_of_nested_3_loops():
+    @with_goto
+    def func():
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
                     goto .end
-            label .end
-            return (i, j)
+        label .end
+        return (i, j, k)
 
-        assert func() == (0, 0)
+    assert func() == (0, 0, 0)
 
-    def test_jump_out_of_nested_3_loops():
-        def func():
-            for i in range(2):
-                for j in range(2):
-                    for k in range(2):
+def test_jump_out_of_nested_4_loops():
+    @with_goto
+    def func():
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
+                    for m in range(2):
                         goto .end
-            label .end
-            return (i, j, k)
+        label .end
+        return (i, j, k, m)
 
-        pytest.raises(SyntaxError, with_goto, func)
-else:
-    def test_jump_out_of_nested_4_loops():
-        @with_goto
-        def func():
-            for i in range(2):
-                for j in range(2):
-                    for k in range(2):
-                        for m in range(2):
+    assert func() == (0, 0, 0, 0)
+
+def test_jump_out_of_nested_5_loops():
+    @with_goto
+    def func():
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
+                    for m in range(2):
+                        for n in range(2):
                             goto .end
-            label .end
-            return (i, j, k, m)
+        label .end
+        return (i, j, k, m, n)
 
-        assert func() == (0, 0, 0, 0)
+    assert func() == (0, 0, 0, 0, 0)
 
-    def test_jump_out_of_nested_5_loops():
-        def func():
-            for i in range(2):
-                for j in range(2):
-                    for k in range(2):
-                        for m in range(2):
-                            for n in range(2):
-                                goto .end
-            label .end
-            return (i, j, k, m, n)
+def test_jump_out_of_nested_11_loops():
+    @with_goto
+    def func():
+        x = 1
+        for i1 in range(2):
+            for i2 in range(2):
+                for i3 in range(2):
+                    for i4 in range(2):
+                        for i5 in range(2):
+                            for i6 in range(2):
+                                for i7 in range(2):
+                                    for i8 in range(2):
+                                        for i9 in range(2):
+                                            for i10 in range(2):
+                                                for i11 in range(2):
+                                                    # These are more than 256 bytes of bytecode
+                                                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+                                                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+                                                    x += x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x
+                                    
+                                                    goto .end
+        label .end
+        return (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11)
 
-        pytest.raises(SyntaxError, with_goto, func)
-
+    assert func() == (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
 def test_jump_across_loops():
     def func():


### PR DESCRIPTION
This fixes issue #19

The fix is to - if there isn't enough space to write the new bytecode in-place - write it at the end of the bytecode array and add jumps to/from there.

It replaces the previous attempted fix for this issue, as including both would be too complex and
is unneeded.

The tests have been updated (previously they were checking that the issue exists), and a new even more extreme test has been added.
Result observed to work correctly in "real" code. (No, not production code :P)

(I've recreated this PR since the previous PR used the master branch of my fork)

